### PR TITLE
fix: stabilize mobile ranking exports

### DIFF
--- a/src/features/ranker/RankingResults.jsx
+++ b/src/features/ranker/RankingResults.jsx
@@ -129,6 +129,11 @@ const getLogoBackgroundStyle = (team, showLogoBg) => {
   };
 };
 
+const getHeadshotSrc = (player) =>
+  player?.headshotUrl ||
+  player?.imageUrl ||
+  `/assets/headshots/${player?.player_id || player?.id}.png`;
+
 // Simple grid display for final rankings. Renders a responsive list of
 // player names with their rank number. Designed to scale up to large player
 // pools by using a multi-column layout.
@@ -140,7 +145,6 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
   const [isLocked, setIsLocked] = useState(false); // Add state to manage lock status
   const [isAdjustMode, setIsAdjustMode] = useState(false);
   const [currentRanking, setCurrentRanking] = useState(ranking);
-  const shareViewRef = useRef(null);
   const exportViewRef = useRef(null); // Separate ref for export content
   const downloadImage = useImageDownload(exportViewRef); // Use export ref for downloads
 
@@ -246,8 +250,7 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
         >
           {currentRanking.map((p, idx) => {
             const logoPath = getLogoPath(p.team);
-            const headshot =
-              p.headshotUrl || `/assets/headshots/${p.player_id || p.id}.png`;
+            const headshot = getHeadshotSrc(p);
             const logoBackgroundStyle = getLogoBackgroundStyle(
               p.team,
               showLogoBg
@@ -267,6 +270,9 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
                       src={headshot}
                       alt={p.name}
                       className="w-full h-full object-cover transition-transform group-hover:scale-105"
+                      loading="eager"
+                      decoding="async"
+                      crossOrigin="anonymous"
                       onError={(e) => {
                         e.target.src = '/assets/headshots/default.png';
                       }}
@@ -291,6 +297,9 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
                             src={logoPath}
                             alt={p.team}
                             className="w-full h-full object-contain"
+                            loading="eager"
+                            decoding="async"
+                            crossOrigin="anonymous"
                             onError={(e) => {
                               e.target.style.display = 'none';
                             }}
@@ -462,8 +471,7 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
           <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 max-w-[1400px] mx-auto">
             {currentRanking.map((p, idx) => {
               const logoPath = getLogoPath(p.team);
-              const headshot =
-                p.headshotUrl || `/assets/headshots/${p.player_id || p.id}.png`;
+              const headshot = getHeadshotSrc(p);
               const logoBackgroundStyle = getLogoBackgroundStyle(
                 p.team,
                 showLogoBg
@@ -483,6 +491,9 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
                         src={headshot}
                         alt={p.name}
                         className="w-full h-full object-cover transition-transform group-hover:scale-105"
+                        loading="eager"
+                        decoding="async"
+                        crossOrigin="anonymous"
                         onError={(e) => {
                           e.target.src = '/assets/headshots/default.png';
                         }}
@@ -507,6 +518,9 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
                               src={logoPath}
                               alt={p.team}
                               className="w-full h-full object-contain"
+                              loading="eager"
+                              decoding="async"
+                              crossOrigin="anonymous"
                               onError={(e) => {
                                 e.target.style.display = 'none';
                               }}
@@ -537,9 +551,7 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
           {createColumns(numCols.base).map((column, colIndex) => (
             <div key={colIndex} className="flex flex-col gap-1 sm:hidden">
               {column.map(({ player: p, rank }) => {
-                const headshot =
-                  p.headshotUrl ||
-                  `/assets/headshots/${p.player_id || p.id}.png`;
+                const headshot = getHeadshotSrc(p);
                 const logoPath = getLogoPath(p.team);
 
                 return (
@@ -554,6 +566,9 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
                       src={headshot}
                       alt=""
                       className="w-10 h-10 rounded-full object-cover"
+                      loading="eager"
+                      decoding="async"
+                      crossOrigin="anonymous"
                       onError={(e) => {
                         e.target.src = '/assets/headshots/default.png';
                       }}
@@ -569,6 +584,9 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
                               src={logoPath}
                               alt={p.team}
                               className="w-full h-full object-contain"
+                              loading="eager"
+                              decoding="async"
+                              crossOrigin="anonymous"
                               onError={(e) => {
                                 e.target.style.display = 'none';
                               }}
@@ -591,9 +609,7 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
               className="hidden sm:flex md:hidden flex-col gap-1"
             >
               {column.map(({ player: p, rank }) => {
-                const headshot =
-                  p.headshotUrl ||
-                  `/assets/headshots/${p.player_id || p.id}.png`;
+                const headshot = getHeadshotSrc(p);
                 const logoPath = getLogoPath(p.team);
 
                 return (
@@ -608,6 +624,9 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
                       src={headshot}
                       alt=""
                       className="w-10 h-10 rounded-full object-cover"
+                      loading="eager"
+                      decoding="async"
+                      crossOrigin="anonymous"
                       onError={(e) => {
                         e.target.src = '/assets/headshots/default.png';
                       }}
@@ -623,6 +642,9 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
                               src={logoPath}
                               alt={p.team}
                               className="w-full h-full object-contain"
+                              loading="eager"
+                              decoding="async"
+                              crossOrigin="anonymous"
                               onError={(e) => {
                                 e.target.style.display = 'none';
                               }}
@@ -642,9 +664,7 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
           {createColumns(numCols.md).map((column, colIndex) => (
             <div key={colIndex} className="hidden md:flex flex-col gap-1">
               {column.map(({ player: p, rank }) => {
-                const headshot =
-                  p.headshotUrl ||
-                  `/assets/headshots/${p.player_id || p.id}.png`;
+                const headshot = getHeadshotSrc(p);
                 const logoPath = getLogoPath(p.team);
 
                 return (
@@ -659,6 +679,9 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
                       src={headshot}
                       alt=""
                       className="w-10 h-10 rounded-full object-cover"
+                      loading="eager"
+                      decoding="async"
+                      crossOrigin="anonymous"
                       onError={(e) => {
                         e.target.src = '/assets/headshots/default.png';
                       }}
@@ -674,6 +697,9 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
                               src={logoPath}
                               alt={p.team}
                               className="w-full h-full object-contain"
+                              loading="eager"
+                              decoding="async"
+                              crossOrigin="anonymous"
                               onError={(e) => {
                                 e.target.style.display = 'none';
                               }}

--- a/src/hooks/useImageDownload.js
+++ b/src/hooks/useImageDownload.js
@@ -1,13 +1,38 @@
 import { toPng } from 'html-to-image';
 import { antonBase64CSS } from '@/fonts/antonBase64';
 
+const waitForImages = async (root) => {
+  if (!root) return;
+
+  const images = Array.from(root.querySelectorAll('img'));
+
+  await Promise.all(
+    images.map((img) => {
+      if (img.complete && img.naturalWidth !== 0) {
+        return Promise.resolve();
+      }
+
+      return new Promise((resolve) => {
+        const handleDone = () => {
+          img.removeEventListener('load', handleDone);
+          img.removeEventListener('error', handleDone);
+          resolve();
+        };
+
+        img.addEventListener('load', handleDone, { once: true });
+        img.addEventListener('error', handleDone, { once: true });
+      });
+    })
+  );
+};
+
 const useImageDownload = (ref) => {
   const download = async (filename, options = {}) => {
     if (!ref.current) return;
+    let styleEl;
     try {
       // 1. Ensure the Base64 font is loaded and injected before export
       const match = antonBase64CSS.match(/base64,([^)]+)\)/);
-      let styleEl;
       if (match) {
         const font = new FontFace(
           'AntonBase64',
@@ -25,11 +50,14 @@ const useImageDownload = (ref) => {
         ref.current.prepend(styleEl);
       }
 
-      // 2. Wait a frame so layout has time to settle
+      // 2. Ensure all images are fully loaded before rendering
+      await waitForImages(ref.current);
+
+      // 3. Wait a frame so layout has time to settle
       await new Promise((r) => requestAnimationFrame(r));
       await new Promise((r) => setTimeout(r, 100));
 
-      // 3. Export as PNG using the element directly
+      // 4. Export as PNG using the element directly
       const dataUrl = await toPng(ref.current, {
         cacheBust: true,
         // Avoid html-to-image font parsing bugs by skipping font
@@ -60,15 +88,17 @@ const useImageDownload = (ref) => {
         },
       });
 
-      // 4. Download
+      // 5. Download
       const link = document.createElement('a');
       link.download = filename;
       link.href = dataUrl;
       link.click();
-
-      if (styleEl) styleEl.remove();
     } catch (err) {
       console.error('Failed to download image', err);
+    } finally {
+      if (styleEl) {
+        styleEl.remove();
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- wait for ranking export images to finish loading before capturing the download
- update QBRankings export to reuse a dedicated five-column grid and eagerly load headshots for mobile
- ensure ranker exports use the same eager headshot loading so mobile captures include portraits

## Testing
- `npm run lint` *(fails: existing prop-types and lint issues across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc27212a2c8326ac5dcfa9f8482e70