### PR TITLE
feat: add interactive backup qb bracket

### DIFF
--- a/src/features/backupBracket/BackupQBBracket.jsx
+++ b/src/features/backupBracket/BackupQBBracket.jsx
@@ -133,8 +133,6 @@ const BackupQBBracket = ({ entrants = [], preferredSize = 32 }) => {
   };
 
   const columnStyle = (roundIndex) => {
-    const centerSpacing = Math.pow(2, roundIndex) * (MATCH_HEIGHT + BASE_GAP);
-    const gap = centerSpacing - MATCH_HEIGHT;
     const offset =
       roundIndex === 0
         ? 0
@@ -142,8 +140,17 @@ const BackupQBBracket = ({ entrants = [], preferredSize = 32 }) => {
 
     return {
       width: `${COLUMN_WIDTH}px`,
-      gap: `${Math.max(gap, 16)}px`,
       paddingTop: `${offset}px`,
+    };
+  };
+
+  const getRoundMeasurements = (roundIndex) => {
+    const centerSpacing = Math.pow(2, roundIndex) * (MATCH_HEIGHT + BASE_GAP);
+    const gap = centerSpacing - MATCH_HEIGHT;
+
+    return {
+      centerSpacing,
+      gap: Math.max(gap, 16),
     };
   };
 
@@ -231,46 +238,48 @@ const BackupQBBracket = ({ entrants = [], preferredSize = 32 }) => {
             <div className="flex" style={{ gap: `${COLUMN_GAP}px` }}>
               {rounds.map((round, roundIndex) => {
                 const label = labels[roundIndex] || `Round ${roundIndex + 1}`;
-                const centerSpacing = Math.pow(2, roundIndex) * (MATCH_HEIGHT + BASE_GAP);
+                const { centerSpacing, gap } = getRoundMeasurements(roundIndex);
 
                 return (
                   <div key={round.roundIndex} className="flex flex-col" style={columnStyle(roundIndex)}>
                     <h3 className="text-center text-sm font-semibold uppercase tracking-widest text-white/60 mb-4">
                       {label}
                     </h3>
-                    {round.matches.map((match) => {
-                      const participants = getMatchParticipants({
-                        rounds,
-                        seededBySeed: seeded.bySeed,
-                        winners,
-                        roundIndex,
-                        matchIndex: match.matchIndex,
-                        entrantsById: seeded.byId,
-                      });
-                      const placeholderLabels =
-                        roundIndex === 0
-                          ? []
-                          : match.sources.map((source) => {
-                              const sourceLabel = labels[source.roundIndex] || `Round ${source.roundIndex + 1}`;
-                              return `Winner of ${sourceLabel} • Match ${source.matchIndex + 1}`;
-                            });
+                    <div className="flex flex-col" style={{ gap: `${gap}px` }}>
+                      {round.matches.map((match) => {
+                        const participants = getMatchParticipants({
+                          rounds,
+                          seededBySeed: seeded.bySeed,
+                          winners,
+                          roundIndex,
+                          matchIndex: match.matchIndex,
+                          entrantsById: seeded.byId,
+                        });
+                        const placeholderLabels =
+                          roundIndex === 0
+                            ? []
+                            : match.sources.map((source) => {
+                                const sourceLabel = labels[source.roundIndex] || `Round ${source.roundIndex + 1}`;
+                                return `Winner of ${sourceLabel} • Match ${source.matchIndex + 1}`;
+                              });
 
-                      return (
-                        <MatchupCard
-                          key={match.id}
-                          roundIndex={roundIndex}
-                          matchIndex={match.matchIndex}
-                          participants={participants}
-                          winnerId={winners[roundIndex][match.matchIndex]}
-                          placeholderLabels={placeholderLabels}
-                          onSelect={(playerId) => handleSelectWinner(roundIndex, match.matchIndex, playerId)}
-                          onHover={() => setHoveredMatch(`${roundIndex}-${match.matchIndex}`)}
-                          onHoverEnd={() => setHoveredMatch(null)}
-                          isLastRound={roundIndex === rounds.length - 1}
-                          centerSpacing={centerSpacing}
-                        />
-                      );
-                    })}
+                        return (
+                          <MatchupCard
+                            key={match.id}
+                            roundIndex={roundIndex}
+                            matchIndex={match.matchIndex}
+                            participants={participants}
+                            winnerId={winners[roundIndex][match.matchIndex]}
+                            placeholderLabels={placeholderLabels}
+                            onSelect={(playerId) => handleSelectWinner(roundIndex, match.matchIndex, playerId)}
+                            onHover={() => setHoveredMatch(`${roundIndex}-${match.matchIndex}`)}
+                            onHoverEnd={() => setHoveredMatch(null)}
+                            isLastRound={roundIndex === rounds.length - 1}
+                            centerSpacing={centerSpacing}
+                          />
+                        );
+                      })}
+                    </div>
                   </div>
                 );
               })}

--- a/src/features/backupBracket/BackupQBBracket.jsx
+++ b/src/features/backupBracket/BackupQBBracket.jsx
@@ -1,0 +1,282 @@
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  buildBracketBlueprint,
+  clearDependentWinners,
+  getChampion,
+  getMatchParticipants,
+  setWinner,
+} from './bracketMath';
+import MatchupCard, { MATCH_HEIGHT } from './MatchupCard';
+import clsx from 'clsx';
+
+const BASE_GAP = 28;
+const COLUMN_WIDTH = 228;
+const COLUMN_GAP = 96;
+const MIN_SCALE = 0.6;
+const MAX_SCALE = 1.6;
+const HOVER_BOOST = 0.18;
+
+const useAutoFit = () => {
+  const containerRef = useRef(null);
+  const contentRef = useRef(null);
+  const [fitScale, setFitScale] = useState(1);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const content = contentRef.current;
+    if (!container || !content) return;
+
+    const calculateFit = () => {
+      const containerWidth = container.clientWidth;
+      const contentWidth = content.scrollWidth;
+      if (!contentWidth) return;
+      const nextFit = Math.min(1, Math.max(MIN_SCALE, containerWidth / contentWidth));
+      setFitScale(nextFit);
+    };
+
+    calculateFit();
+
+    if (typeof ResizeObserver !== 'undefined') {
+      const resizeObserver = new ResizeObserver(calculateFit);
+      resizeObserver.observe(container);
+      resizeObserver.observe(content);
+
+      return () => {
+        resizeObserver.disconnect();
+      };
+    }
+
+    window.addEventListener('resize', calculateFit);
+    return () => {
+      window.removeEventListener('resize', calculateFit);
+    };
+  }, []);
+
+  return { containerRef, contentRef, fitScale };
+};
+
+const BackupQBBracket = ({ entrants = [], preferredSize = 32 }) => {
+  const blueprint = useMemo(() => buildBracketBlueprint(entrants, preferredSize), [entrants, preferredSize]);
+  const { size, seeded, rounds, labels } = blueprint;
+  const [winners, setWinners] = useState(blueprint.winners);
+  const [hoveredMatch, setHoveredMatch] = useState(null);
+  const [isManualZoom, setIsManualZoom] = useState(false);
+
+  const { containerRef, contentRef, fitScale } = useAutoFit();
+  const [baseScale, setBaseScale] = useState(1);
+  const [displayScale, setDisplayScale] = useState(1);
+
+  useEffect(() => {
+    setWinners(blueprint.winners);
+    setHoveredMatch(null);
+    setIsManualZoom(false);
+  }, [blueprint]);
+
+  useEffect(() => {
+    if (!isManualZoom) {
+      setBaseScale(fitScale);
+    }
+  }, [fitScale, isManualZoom]);
+
+  useEffect(() => {
+    const focusScale = Math.min(MAX_SCALE, Math.max(baseScale, baseScale + HOVER_BOOST));
+    if (hoveredMatch) {
+      setDisplayScale(focusScale);
+    } else {
+      setDisplayScale(baseScale);
+    }
+  }, [baseScale, hoveredMatch]);
+
+  const handleSelectWinner = (roundIndex, matchIndex, playerId) => {
+    setWinners((current) => {
+      const existing = current[roundIndex][matchIndex];
+      let updated = current;
+      if (existing === playerId) {
+        updated = setWinner(current, roundIndex, matchIndex, null);
+        updated = clearDependentWinners(updated, roundIndex, matchIndex);
+        return updated;
+      }
+
+      updated = setWinner(current, roundIndex, matchIndex, playerId);
+      updated = clearDependentWinners(updated, roundIndex, matchIndex);
+      return updated;
+    });
+  };
+
+  const champion = useMemo(() => getChampion(winners, seeded.byId), [winners, seeded.byId]);
+
+  const handleZoomIn = () => {
+    setIsManualZoom(true);
+    setBaseScale((scale) => Math.min(MAX_SCALE, scale + 0.15));
+  };
+
+  const handleZoomOut = () => {
+    setIsManualZoom(true);
+    setBaseScale((scale) => Math.max(MIN_SCALE, scale - 0.15));
+  };
+
+  const handleFit = () => {
+    setIsManualZoom(false);
+    setBaseScale(fitScale);
+  };
+
+  const handleResetZoom = () => {
+    setIsManualZoom(true);
+    setBaseScale(1);
+  };
+
+  const handleResetBracket = () => {
+    setWinners(blueprint.winners);
+    setHoveredMatch(null);
+    setIsManualZoom(false);
+    setBaseScale(fitScale);
+  };
+
+  const columnStyle = (roundIndex) => {
+    const centerSpacing = Math.pow(2, roundIndex) * (MATCH_HEIGHT + BASE_GAP);
+    const gap = centerSpacing - MATCH_HEIGHT;
+    const offset = roundIndex === 0 ? 0 : centerSpacing / 2 - MATCH_HEIGHT / 2;
+
+    return {
+      width: `${COLUMN_WIDTH}px`,
+      gap: `${Math.max(gap, 16)}px`,
+      paddingTop: `${offset}px`,
+    };
+  };
+
+  if (!size) {
+    return (
+      <div className="bg-neutral-900/60 border border-white/10 rounded-2xl p-6 text-center text-white/70">
+        Unable to load enough backup quarterbacks for a bracket.
+      </div>
+    );
+  }
+
+  return (
+    <section className="bg-neutral-900/60 border border-white/10 rounded-3xl shadow-2xl overflow-hidden">
+      <div className="flex flex-col gap-4 border-b border-white/10 px-6 py-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-white">Backup QB Bracket</h2>
+          <p className="text-white/60 text-sm">
+            {size}-quarterback single-elimination showdown. Click a QB to advance them and build your champion.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            className="px-3 py-2 text-xs font-semibold rounded-md bg-white/10 hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-orange-400"
+            onClick={handleZoomOut}
+          >
+            Zoom Out
+          </button>
+          <button
+            type="button"
+            className="px-3 py-2 text-xs font-semibold rounded-md bg-white/10 hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-orange-400"
+            onClick={handleZoomIn}
+          >
+            Zoom In
+          </button>
+          <button
+            type="button"
+            className="px-3 py-2 text-xs font-semibold rounded-md bg-white/10 hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-orange-400"
+            onClick={handleFit}
+          >
+            Fit to Screen
+          </button>
+          <button
+            type="button"
+            className="px-3 py-2 text-xs font-semibold rounded-md bg-white/10 hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-orange-400"
+            onClick={handleResetZoom}
+          >
+            Reset Zoom
+          </button>
+          <button
+            type="button"
+            className="px-3 py-2 text-xs font-semibold rounded-md bg-orange-500/20 text-orange-200 hover:bg-orange-500/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-orange-400"
+            onClick={handleResetBracket}
+          >
+            Reset Bracket
+          </button>
+        </div>
+      </div>
+
+      {champion && (
+        <div className="px-6 pt-4">
+          <div className="rounded-2xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-3 flex items-center gap-3">
+            <span className="text-2xl" role="img" aria-label="Champion">
+              🏆
+            </span>
+            <div>
+              <p className="text-sm text-emerald-200/80 uppercase tracking-wide">Champion</p>
+              <p className="text-lg font-semibold text-emerald-100">{champion.display_name}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div ref={containerRef} className="relative overflow-hidden">
+        <div className="overflow-auto">
+          <div
+            ref={contentRef}
+            className={clsx('transition-transform duration-300 ease-out px-6 py-10')}
+            style={{
+              transform: `scale(${displayScale})`,
+              transformOrigin: 'left top',
+              minWidth: `${rounds.length * (COLUMN_WIDTH + COLUMN_GAP) + COLUMN_GAP}px`,
+            }}
+          >
+            <div className="flex" style={{ gap: `${COLUMN_GAP}px` }}>
+              {rounds.map((round, roundIndex) => {
+                const label = labels[roundIndex] || `Round ${roundIndex + 1}`;
+                const centerSpacing = Math.pow(2, roundIndex) * (MATCH_HEIGHT + BASE_GAP);
+
+                return (
+                  <div key={round.roundIndex} className="flex flex-col" style={columnStyle(roundIndex)}>
+                    <h3 className="text-center text-sm font-semibold uppercase tracking-widest text-white/60 mb-4">
+                      {label}
+                    </h3>
+                    {round.matches.map((match) => {
+                      const participants = getMatchParticipants({
+                        rounds,
+                        seededBySeed: seeded.bySeed,
+                        winners,
+                        roundIndex,
+                        matchIndex: match.matchIndex,
+                        entrantsById: seeded.byId,
+                      });
+                      const placeholderLabels =
+                        roundIndex === 0
+                          ? []
+                          : match.sources.map((source) => {
+                              const sourceLabel = labels[source.roundIndex] || `Round ${source.roundIndex + 1}`;
+                              return `Winner of ${sourceLabel} • Match ${source.matchIndex + 1}`;
+                            });
+
+                      return (
+                        <MatchupCard
+                          key={match.id}
+                          roundIndex={roundIndex}
+                          matchIndex={match.matchIndex}
+                          participants={participants}
+                          winnerId={winners[roundIndex][match.matchIndex]}
+                          placeholderLabels={placeholderLabels}
+                          onSelect={(playerId) => handleSelectWinner(roundIndex, match.matchIndex, playerId)}
+                          onHover={() => setHoveredMatch(`${roundIndex}-${match.matchIndex}`)}
+                          onHoverEnd={() => setHoveredMatch(null)}
+                          isLastRound={roundIndex === rounds.length - 1}
+                          centerSpacing={centerSpacing}
+                        />
+                      );
+                    })}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default BackupQBBracket;

--- a/src/features/backupBracket/BackupQBBracket.jsx
+++ b/src/features/backupBracket/BackupQBBracket.jsx
@@ -135,7 +135,10 @@ const BackupQBBracket = ({ entrants = [], preferredSize = 32 }) => {
   const columnStyle = (roundIndex) => {
     const centerSpacing = Math.pow(2, roundIndex) * (MATCH_HEIGHT + BASE_GAP);
     const gap = centerSpacing - MATCH_HEIGHT;
-    const offset = roundIndex === 0 ? 0 : centerSpacing / 2 - MATCH_HEIGHT / 2;
+    const offset =
+      roundIndex === 0
+        ? 0
+        : ((Math.pow(2, roundIndex) - 1) / 2) * (MATCH_HEIGHT + BASE_GAP);
 
     return {
       width: `${COLUMN_WIDTH}px`,

--- a/src/features/backupBracket/MatchupCard.jsx
+++ b/src/features/backupBracket/MatchupCard.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import clsx from 'clsx';
 
-const MATCH_HEIGHT = 92;
+const MATCH_HEIGHT = 96;
 const CONNECTOR_LENGTH = 56;
 
 const MatchupCard = ({
@@ -59,13 +59,13 @@ const MatchupCard = ({
   return (
     <div
       className="relative"
-      style={{ minHeight: `${MATCH_HEIGHT}px` }}
+      style={{ height: `${MATCH_HEIGHT}px` }}
       onMouseEnter={onHover}
       onMouseLeave={onHoverEnd}
       onFocus={onHover}
       onBlur={onHoverEnd}
     >
-      <div className="rounded-xl border border-white/10 bg-neutral-800/70 backdrop-blur-sm shadow-lg overflow-hidden">
+      <div className="h-full rounded-xl border border-white/10 bg-neutral-800/70 backdrop-blur-sm shadow-lg overflow-hidden flex flex-col">
         {participantRows.map((participant, index) => {
           const showDivider = index === 1;
           const statusClasses =
@@ -80,10 +80,9 @@ const MatchupCard = ({
               key={participant.id}
               type="button"
               className={clsx(
-                'w-full text-left px-4 py-3 transition-colors focus:outline-none',
+                'w-full text-left px-4 py-3 transition-colors focus:outline-none flex-1 flex items-center justify-between gap-3',
                 statusClasses,
-                showDivider && 'border-t border-white/10',
-                'flex items-center justify-between gap-3'
+                showDivider && 'border-t border-white/10'
               )}
               disabled={participant.isPlaceholder}
               onClick={() => handleSelect(participant)}
@@ -94,6 +93,7 @@ const MatchupCard = ({
                   ? 'Waiting on previous result'
                   : `Select ${participant.label} as winner`
               }
+              style={{ minHeight: `${MATCH_HEIGHT / participantRows.length}px` }}
             >
               <div className="flex items-center gap-3">
                 <span className="text-xs font-semibold text-white/50">
@@ -110,15 +110,24 @@ const MatchupCard = ({
                   )}
                 </div>
               </div>
-              {participant.status === 'winner' ? (
-                <span className="text-emerald-300 text-xs font-semibold">Advanced</span>
-              ) : participant.status === 'eliminated' ? (
-                <span className="text-white/30 text-xs">Out</span>
-              ) : (
-                <span className="text-white/40 text-xs">
-                  {participant.isPlaceholder ? 'TBD' : 'Pick'}
-                </span>
-              )}
+              <span
+                className={clsx(
+                  'text-xs font-semibold uppercase tracking-wide text-right min-w-[44px]',
+                  participant.status === 'winner'
+                    ? 'text-emerald-300'
+                    : participant.status === 'eliminated'
+                    ? 'text-white/30'
+                    : 'text-white/40'
+                )}
+              >
+                {participant.status === 'winner'
+                  ? ' '
+                  : participant.status === 'eliminated'
+                  ? 'Out'
+                  : participant.isPlaceholder
+                  ? 'TBD'
+                  : 'Pick'}
+              </span>
             </button>
           );
         })}
@@ -127,18 +136,19 @@ const MatchupCard = ({
       {!isLastRound && (
         <div
           aria-hidden="true"
-          className="absolute top-1/2 right-[-56px] h-px bg-white/10"
-          style={{ width: `${CONNECTOR_LENGTH}px` }}
+          className="absolute top-1/2 h-px bg-white/10"
+          style={{ width: `${CONNECTOR_LENGTH}px`, right: `-${CONNECTOR_LENGTH}px` }}
         />
       )}
 
       {!isLastRound && matchIndex % 2 === 0 && (
         <div
           aria-hidden="true"
-          className="absolute right-[-56px] w-px bg-white/10"
+          className="absolute w-px bg-white/10"
           style={{
             top: '50%',
             height: `${centerSpacing}px`,
+            right: `-${CONNECTOR_LENGTH}px`,
           }}
         />
       )}

--- a/src/features/backupBracket/MatchupCard.jsx
+++ b/src/features/backupBracket/MatchupCard.jsx
@@ -1,0 +1,150 @@
+import React, { useMemo } from 'react';
+import clsx from 'clsx';
+
+const MATCH_HEIGHT = 92;
+const CONNECTOR_LENGTH = 56;
+
+const MatchupCard = ({
+  roundIndex,
+  matchIndex,
+  participants,
+  winnerId,
+  onSelect,
+  onHover,
+  onHoverEnd,
+  isLastRound,
+  centerSpacing,
+  placeholderLabels = [],
+}) => {
+  const participantRows = useMemo(() => {
+    return participants.map((participant, participantIndex) => {
+      if (!participant) {
+        return {
+          id: `placeholder-${participantIndex}`,
+          label: placeholderLabels[participantIndex] || 'TBD',
+          seed: null,
+          status: 'pending',
+          team: '',
+          isPlaceholder: true,
+        };
+      }
+
+      const isWinner = winnerId === participant.id;
+      const status = winnerId ? (isWinner ? 'winner' : 'eliminated') : 'pending';
+
+      return {
+        id: participant.id,
+        label: participant.display_name,
+        seed: participant.seed,
+        status,
+        team: participant.team || 'FA',
+        isPlaceholder: false,
+      };
+    });
+  }, [participants, winnerId]);
+
+  const handleSelect = (participant) => {
+    if (participant.isPlaceholder) return;
+    onSelect(participant.id);
+  };
+
+  const handleKeyDown = (event, participant) => {
+    if (participant.isPlaceholder) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      onSelect(participant.id);
+    }
+  };
+
+  return (
+    <div
+      className="relative"
+      style={{ minHeight: `${MATCH_HEIGHT}px` }}
+      onMouseEnter={onHover}
+      onMouseLeave={onHoverEnd}
+      onFocus={onHover}
+      onBlur={onHoverEnd}
+    >
+      <div className="rounded-xl border border-white/10 bg-neutral-800/70 backdrop-blur-sm shadow-lg overflow-hidden">
+        {participantRows.map((participant, index) => {
+          const showDivider = index === 1;
+          const statusClasses =
+            participant.status === 'winner'
+              ? 'bg-emerald-500/20 text-emerald-200 border-emerald-500/40 shadow-inner'
+              : participant.status === 'eliminated'
+              ? 'bg-neutral-800/40 text-white/40 line-through'
+              : 'hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-orange-400';
+
+          return (
+            <button
+              key={participant.id}
+              type="button"
+              className={clsx(
+                'w-full text-left px-4 py-3 transition-colors focus:outline-none',
+                statusClasses,
+                showDivider && 'border-t border-white/10',
+                'flex items-center justify-between gap-3'
+              )}
+              disabled={participant.isPlaceholder}
+              onClick={() => handleSelect(participant)}
+              onKeyDown={(event) => handleKeyDown(event, participant)}
+              aria-pressed={participant.status === 'winner'}
+              aria-label={
+                participant.isPlaceholder
+                  ? 'Waiting on previous result'
+                  : `Select ${participant.label} as winner`
+              }
+            >
+              <div className="flex items-center gap-3">
+                <span className="text-xs font-semibold text-white/50">
+                  {participant.seed ? `#${participant.seed}` : '—'}
+                </span>
+                <div className="flex flex-col">
+                  <span className="font-semibold text-sm md:text-base">
+                    {participant.label}
+                  </span>
+                  {participant.team && !participant.isPlaceholder && (
+                    <span className="text-[10px] uppercase tracking-widest text-white/40">
+                      {participant.team}
+                    </span>
+                  )}
+                </div>
+              </div>
+              {participant.status === 'winner' ? (
+                <span className="text-emerald-300 text-xs font-semibold">Advanced</span>
+              ) : participant.status === 'eliminated' ? (
+                <span className="text-white/30 text-xs">Out</span>
+              ) : (
+                <span className="text-white/40 text-xs">
+                  {participant.isPlaceholder ? 'TBD' : 'Pick'}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {!isLastRound && (
+        <div
+          aria-hidden="true"
+          className="absolute top-1/2 right-[-56px] h-px bg-white/10"
+          style={{ width: `${CONNECTOR_LENGTH}px` }}
+        />
+      )}
+
+      {!isLastRound && matchIndex % 2 === 0 && (
+        <div
+          aria-hidden="true"
+          className="absolute right-[-56px] w-px bg-white/10"
+          style={{
+            top: '50%',
+            height: `${centerSpacing}px`,
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default MatchupCard;
+export { MATCH_HEIGHT };

--- a/src/features/backupBracket/bracketMath.js
+++ b/src/features/backupBracket/bracketMath.js
@@ -1,0 +1,222 @@
+const collator = new Intl.Collator('en', {
+  sensitivity: 'base',
+  numeric: true,
+});
+
+const fallbackName = (entrant) => {
+  return (
+    entrant?.display_name ||
+    entrant?.displayName ||
+    entrant?.name ||
+    entrant?.fullName ||
+    entrant?.playerName ||
+    entrant?.id ||
+    'Unknown QB'
+  );
+};
+
+export const determineBracketSize = (entrantsLength, preferredSize = 32) => {
+  if (!entrantsLength) return 0;
+  if (entrantsLength >= preferredSize) return preferredSize;
+  if (preferredSize === 32 && entrantsLength >= 16) return 16;
+
+  const highestPowerOfTwo = 2 ** Math.floor(Math.log2(Math.max(entrantsLength, 1)));
+  return Math.max(2, highestPowerOfTwo);
+};
+
+export const generateSeedOrder = (size) => {
+  if (size < 2 || (size & (size - 1)) !== 0) {
+    throw new Error('Bracket size must be a power of two greater than or equal to 2');
+  }
+
+  let seeds = [1, 2];
+  while (seeds.length < size) {
+    const currentSize = seeds.length * 2;
+    const next = [];
+    for (let i = 0; i < seeds.length; i++) {
+      next.push(seeds[i]);
+      next.push(currentSize + 1 - seeds[i]);
+    }
+    seeds = next;
+  }
+
+  return seeds;
+};
+
+export const seedEntrants = (entrants, size) => {
+  const trimmedSize = Math.min(size, entrants.length);
+  const seededEntrants = entrants
+    .slice(0, trimmedSize)
+    .map((entrant) => ({
+      ...entrant,
+      display_name: fallbackName(entrant),
+    }))
+    .sort((a, b) => {
+      const nameA = fallbackName(a);
+      const nameB = fallbackName(b);
+      return collator.compare(nameA, nameB);
+    })
+    .map((entrant, index) => ({
+      ...entrant,
+      seed: index + 1,
+    }));
+
+  const byId = {};
+  const bySeed = new Array(trimmedSize).fill(null);
+
+  seededEntrants.forEach((entrant) => {
+    byId[entrant.id] = entrant;
+    bySeed[entrant.seed - 1] = entrant;
+  });
+
+  return {
+    list: seededEntrants,
+    byId,
+    bySeed,
+  };
+};
+
+export const getRoundLabels = (size) => {
+  const labels32 = ['Round of 32', 'Sweet 16', 'Elite Eight', 'Final Four', 'Championship'];
+  const labels16 = ['Round of 16', 'Elite Eight', 'Final Four', 'Championship'];
+  const labels8 = ['Quarterfinals', 'Semifinals', 'Championship'];
+  const labels4 = ['Semifinals', 'Championship'];
+
+  if (size >= 32) return labels32;
+  if (size === 16) return labels16;
+  if (size === 8) return labels8;
+  if (size === 4) return labels4;
+  return ['Final'];
+};
+
+export const createBracketRounds = (size) => {
+  const rounds = [];
+  const seedOrder = generateSeedOrder(size);
+  const totalRounds = Math.log2(size);
+
+  for (let roundIndex = 0; roundIndex < totalRounds; roundIndex++) {
+    const matchesInRound = size / Math.pow(2, roundIndex + 1);
+    const matches = [];
+
+    for (let matchIndex = 0; matchIndex < matchesInRound; matchIndex++) {
+      if (roundIndex === 0) {
+        const seedIndex = matchIndex * 2;
+        matches.push({
+          id: `R${roundIndex + 1}-M${matchIndex + 1}`,
+          label: `Match ${matchIndex + 1}`,
+          roundIndex,
+          matchIndex,
+          seeds: [seedOrder[seedIndex], seedOrder[seedIndex + 1]],
+          sources: [],
+        });
+      } else {
+        matches.push({
+          id: `R${roundIndex + 1}-M${matchIndex + 1}`,
+          label: `Match ${matchIndex + 1}`,
+          roundIndex,
+          matchIndex,
+          seeds: [],
+          sources: [
+            { roundIndex: roundIndex - 1, matchIndex: matchIndex * 2 },
+            { roundIndex: roundIndex - 1, matchIndex: matchIndex * 2 + 1 },
+          ],
+        });
+      }
+    }
+
+    rounds.push({
+      roundIndex,
+      matches,
+    });
+  }
+
+  return rounds;
+};
+
+export const createInitialWinners = (size) => {
+  const totalRounds = Math.log2(size);
+  return Array.from({ length: totalRounds }, (_, roundIndex) => {
+    const matchesInRound = size / Math.pow(2, roundIndex + 1);
+    return new Array(matchesInRound).fill(null);
+  });
+};
+
+export const getMatchParticipants = ({
+  rounds,
+  seededBySeed,
+  winners,
+  roundIndex,
+  matchIndex,
+  entrantsById,
+}) => {
+  const match = rounds[roundIndex]?.matches[matchIndex];
+  if (!match) return [null, null];
+
+  if (roundIndex === 0) {
+    return match.seeds.map((seed) => {
+      const entrant = seededBySeed[seed - 1];
+      if (!entrant) return null;
+      return entrant;
+    });
+  }
+
+  return match.sources.map((source) => {
+    const winnerId = winners[source.roundIndex]?.[source.matchIndex];
+    if (!winnerId) return null;
+    return entrantsById[winnerId] || null;
+  });
+};
+
+export const clearDependentWinners = (winners, roundIndex, matchIndex) => {
+  const cloned = winners.map((round) => [...round]);
+  let currentRound = roundIndex + 1;
+  let currentMatch = Math.floor(matchIndex / 2);
+
+  while (currentRound < cloned.length) {
+    cloned[currentRound][currentMatch] = null;
+    currentMatch = Math.floor(currentMatch / 2);
+    currentRound += 1;
+  }
+
+  return cloned;
+};
+
+export const setWinner = (winners, roundIndex, matchIndex, playerId) => {
+  const cloned = winners.map((round) => [...round]);
+  cloned[roundIndex][matchIndex] = playerId;
+  return cloned;
+};
+
+export const getChampion = (winners, entrantsById) => {
+  if (!winners.length) return null;
+  const championId = winners[winners.length - 1]?.[0];
+  if (!championId) return null;
+  return entrantsById[championId] || null;
+};
+
+export const buildBracketBlueprint = (entrants, preferredSize = 32) => {
+  const bracketSize = determineBracketSize(entrants.length, preferredSize);
+  if (bracketSize < 2) {
+    return {
+      size: 0,
+      rounds: [],
+      seeded: { list: [], byId: {}, bySeed: [] },
+      labels: [],
+      winners: [],
+    };
+  }
+
+  const seeded = seedEntrants(entrants, bracketSize);
+  const rounds = createBracketRounds(bracketSize);
+  const labels = getRoundLabels(bracketSize);
+  const winners = createInitialWinners(bracketSize);
+
+  return {
+    size: bracketSize,
+    seeded,
+    rounds,
+    labels,
+    winners,
+  };
+};
+

--- a/src/pages/BackupQBsHome.jsx
+++ b/src/pages/BackupQBsHome.jsx
@@ -1,8 +1,24 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { FireIcon } from '@heroicons/react/24/outline';
+import BackupQBBracket from '@/features/backupBracket/BackupQBBracket';
+import usePlayerData from '@/hooks/usePlayerData.js';
+import { filterBackupQBs } from '@/utils/backupQBs/backupQBClassification';
 
 const BackupQBsHome = () => {
+  const { players } = usePlayerData();
+  const backupQBs = useMemo(() => filterBackupQBs(players || []), [players]);
+  const bracketEntrants = useMemo(
+    () =>
+      backupQBs.map((qb) => ({
+        id: qb.id || qb.player_id,
+        display_name:
+          qb.display_name || qb.displayName || qb.fullName || qb.name || qb.player_name || qb.id,
+        team: qb.bio?.Team || qb.team || qb.currentTeam || 'FA',
+      })),
+    [backupQBs]
+  );
+
   return (
     <div className="min-h-screen bg-neutral-900 text-white py-12 px-4">
       <div className="max-w-6xl mx-auto space-y-12">
@@ -13,6 +29,15 @@ const BackupQBsHome = () => {
             A celebration of the unsung heroes who keep NFL teams running when
             called upon.
           </p>
+        </div>
+
+        {/* Bracket Section */}
+        <div className="space-y-6">
+          <p className="text-white/70 text-sm text-center max-w-3xl mx-auto">
+            Rank the best reserves in football with our interactive bracket. Choose winners, watch them advance,
+            and crown the ultimate backup quarterback champion.
+          </p>
+          <BackupQBBracket entrants={bracketEntrants} preferredSize={32} />
         </div>
 
         {/* Hall of Fame Card */}

--- a/tests/AnchorComparison.test.jsx
+++ b/tests/AnchorComparison.test.jsx
@@ -13,7 +13,7 @@ describe('AnchorComparison', () => {
     const handle = vi.fn();
     render(<AnchorComparison anchor={anchor} players={players} onComplete={handle} />);
     fireEvent.click(screen.getByText('Alpha'));
-    fireEvent.click(screen.getByText('Confirm'));
+    fireEvent.click(screen.getByText('Confirm Selection'));
     expect(handle).toHaveBeenCalledWith(['1']);
   });
 });

--- a/tests/BackupQBBracket.test.jsx
+++ b/tests/BackupQBBracket.test.jsx
@@ -28,9 +28,24 @@ describe('BackupQBBracket component', () => {
     fireEvent.click(qb8Button);
 
     expect(screen.queryByText('Winner of Round of 16 • Match 1')).not.toBeInTheDocument();
-    expect(screen.getAllByText('Advanced').length).toBeGreaterThan(0);
 
-    fireEvent.click(qb1Button);
+    const updatedQb1Button = screen
+      .getAllByRole('button', { name: /Select QB 1 as winner/i })
+      .find((button) => button.getAttribute('aria-label')?.includes('QB 1'));
+    const updatedQb8Button = screen
+      .getAllByRole('button', { name: /Select QB 8 as winner/i })
+      .find((button) => button.getAttribute('aria-label')?.includes('QB 8'));
+
+    expect(updatedQb1Button).toHaveAttribute('aria-pressed', 'true');
+    expect(updatedQb8Button).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(updatedQb1Button);
     expect(await screen.findByText('Winner of Round of 16 • Match 1')).toBeInTheDocument();
+
+    const resetQb1Button = screen
+      .getAllByRole('button', { name: /Select QB 1 as winner/i })
+      .find((button) => button.getAttribute('aria-label')?.includes('QB 1'));
+
+    expect(resetQb1Button).toHaveAttribute('aria-pressed', 'false');
   });
 });

--- a/tests/BackupQBBracket.test.jsx
+++ b/tests/BackupQBBracket.test.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import BackupQBBracket from '@/features/backupBracket/BackupQBBracket.jsx';
+
+const createEntrants = (count) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `qb-${index + 1}`,
+    display_name: `QB ${index + 1}`,
+    team: `T${index + 1}`,
+  }));
+
+describe('BackupQBBracket component', () => {
+  it('allows selecting and clearing winners', async () => {
+    render(<BackupQBBracket entrants={createEntrants(16)} preferredSize={16} />);
+
+    expect(await screen.findByText('Winner of Round of 16 • Match 1')).toBeInTheDocument();
+
+    const allButtons = screen.getAllByRole('button', { name: /Select QB/i });
+    const qb1Button = allButtons.find((button) => button.getAttribute('aria-label')?.includes('QB 1'));
+    const qb8Button = allButtons.find((button) => button.getAttribute('aria-label')?.includes('QB 8'));
+
+    expect(qb1Button).toBeTruthy();
+    expect(qb8Button).toBeTruthy();
+
+    fireEvent.click(qb1Button);
+    fireEvent.click(qb8Button);
+
+    expect(screen.queryByText('Winner of Round of 16 • Match 1')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Advanced').length).toBeGreaterThan(0);
+
+    fireEvent.click(qb1Button);
+    expect(await screen.findByText('Winner of Round of 16 • Match 1')).toBeInTheDocument();
+  });
+});

--- a/tests/RankingSetup.test.jsx
+++ b/tests/RankingSetup.test.jsx
@@ -13,7 +13,7 @@ describe('RankingSetup', () => {
     render(<RankingSetup playerPool={samplePlayers} onComplete={handle} />);
     const top = screen.getByTestId('top-tier');
     fireEvent.click(within(top).getByText('Alpha'));
-    fireEvent.click(screen.getByText('Start'));
+    fireEvent.click(screen.getByText('Go'));
     expect(handle).toHaveBeenCalledWith({
       topTier: ['1'],
       bottomTier: [],

--- a/tests/backupBracketMath.test.js
+++ b/tests/backupBracketMath.test.js
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBracketBlueprint,
+  clearDependentWinners,
+  determineBracketSize,
+  getMatchParticipants,
+  setWinner,
+} from '@/features/backupBracket/bracketMath';
+
+const createEntrants = (count) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `qb-${index + 1}`,
+    display_name: `QB ${index + 1}`,
+    team: `T${index + 1}`,
+  }));
+
+describe('backup bracket math', () => {
+  it('determines bracket sizes with 32 preference', () => {
+    expect(determineBracketSize(40, 32)).toBe(32);
+    expect(determineBracketSize(20, 32)).toBe(16);
+    expect(determineBracketSize(9, 32)).toBe(8);
+    expect(determineBracketSize(1, 32)).toBe(2);
+  });
+
+  it('builds bracket blueprint for 32 entrants', () => {
+    const blueprint = buildBracketBlueprint(createEntrants(32));
+    expect(blueprint.size).toBe(32);
+    expect(blueprint.rounds).toHaveLength(5);
+    expect(blueprint.rounds[0].matches).toHaveLength(16);
+    expect(blueprint.rounds[1].matches).toHaveLength(8);
+    expect(blueprint.rounds[4].matches).toHaveLength(1);
+  });
+
+  it('builds bracket blueprint for 16 entrants fallback', () => {
+    const blueprint = buildBracketBlueprint(createEntrants(18));
+    expect(blueprint.size).toBe(16);
+    expect(blueprint.rounds).toHaveLength(4);
+    expect(blueprint.rounds[0].matches).toHaveLength(8);
+    expect(blueprint.rounds[3].matches).toHaveLength(1);
+  });
+
+  it('propagates winners to subsequent rounds', () => {
+    const blueprint = buildBracketBlueprint(createEntrants(16));
+    let winners = blueprint.winners;
+    const firstMatchParticipants = getMatchParticipants({
+      rounds: blueprint.rounds,
+      seededBySeed: blueprint.seeded.bySeed,
+      winners,
+      roundIndex: 0,
+      matchIndex: 0,
+      entrantsById: blueprint.seeded.byId,
+    });
+
+    const secondMatchParticipants = getMatchParticipants({
+      rounds: blueprint.rounds,
+      seededBySeed: blueprint.seeded.bySeed,
+      winners,
+      roundIndex: 0,
+      matchIndex: 1,
+      entrantsById: blueprint.seeded.byId,
+    });
+
+    winners = setWinner(winners, 0, 0, firstMatchParticipants[0].id);
+    winners = clearDependentWinners(winners, 0, 0);
+    winners = setWinner(winners, 0, 1, secondMatchParticipants[0].id);
+    winners = clearDependentWinners(winners, 0, 1);
+
+    const nextRoundParticipants = getMatchParticipants({
+      rounds: blueprint.rounds,
+      seededBySeed: blueprint.seeded.bySeed,
+      winners,
+      roundIndex: 1,
+      matchIndex: 0,
+      entrantsById: blueprint.seeded.byId,
+    });
+
+    expect(nextRoundParticipants[0]?.id).toBe(firstMatchParticipants[0].id);
+    expect(nextRoundParticipants[1]?.id).toBe(secondMatchParticipants[0].id);
+  });
+
+  it('clears downstream winners when an earlier pick is changed', () => {
+    const blueprint = buildBracketBlueprint(createEntrants(16));
+    let winners = blueprint.winners;
+    const [topWinner] = getMatchParticipants({
+      rounds: blueprint.rounds,
+      seededBySeed: blueprint.seeded.bySeed,
+      winners,
+      roundIndex: 0,
+      matchIndex: 0,
+      entrantsById: blueprint.seeded.byId,
+    });
+    const [, opponent] = getMatchParticipants({
+      rounds: blueprint.rounds,
+      seededBySeed: blueprint.seeded.bySeed,
+      winners,
+      roundIndex: 0,
+      matchIndex: 1,
+      entrantsById: blueprint.seeded.byId,
+    });
+
+    winners = setWinner(winners, 0, 0, topWinner.id);
+    winners = clearDependentWinners(winners, 0, 0);
+    winners = setWinner(winners, 0, 1, opponent.id);
+    winners = clearDependentWinners(winners, 0, 1);
+    winners = setWinner(winners, 1, 0, topWinner.id);
+    winners = clearDependentWinners(winners, 1, 0);
+
+    winners = setWinner(winners, 0, 0, null);
+    winners = clearDependentWinners(winners, 0, 0);
+
+    const downstreamWinner = winners[1][0];
+    expect(downstreamWinner).toBeNull();
+  });
+});

--- a/tests/setupDebug.js
+++ b/tests/setupDebug.js
@@ -1,0 +1,2 @@
+// Vitest setup placeholder for DOM debugging hooks.
+export default {};


### PR DESCRIPTION
## Summary
- build a reusable backup quarterback bracket with fit/zoom controls, champion callouts, and hover scaling so winners advance and losses clear downstream rounds【F:src/features/backupBracket/BackupQBBracket.jsx†L1-L279】【F:src/features/backupBracket/MatchupCard.jsx†L1-L145】
- extract bracket math helpers for deterministic seeding, round generation, and winner propagation logic shared by the UI and tests【F:src/features/backupBracket/bracketMath.js†L1-L221】
- surface the bracket on the Backup QB Central page by filtering backup passers from player data before passing them to the component【F:src/pages/BackupQBsHome.jsx†L1-L41】
- cover bracket generation and interactions with new unit/component tests and align existing ranker tests with the current button copy while adding a Vitest setup stub【F:tests/backupBracketMath.test.js†L1-L114】【F:tests/BackupQBBracket.test.jsx†L1-L35】【F:tests/RankingSetup.test.jsx†L1-L24】【F:tests/AnchorComparison.test.jsx†L1-L19】【F:tests/setupDebug.js†L1-L2】

## Testing
- npm test -- --run

## Notes
- **Using the bracket:** navigate to `/backup-qbs` to find the new single-elimination bracket beneath the page header; click any QB to advance them, use the zoom buttons to focus, and reset picks with the "Reset Bracket" control.【F:src/pages/BackupQBsHome.jsx†L1-L41】【F:src/features/backupBracket/BackupQBBracket.jsx†L155-L279】
- **Seeding approach:** entrants are filtered backup quarterbacks sorted alphabetically by name, then seeded with a standard tournament layout that supports 32-slot brackets with a 16-entrant fallback.【F:src/pages/BackupQBsHome.jsx†L9-L20】【F:src/features/backupBracket/bracketMath.js†L18-L221】
- **Running tests:** execute `npm test -- --run` to validate the bracket math and component interactions alongside the existing suite.【0af1a2†L1-L8】

------
https://chatgpt.com/codex/tasks/task_e_68cfcb2c80fc8326a9847c22fcd5be50