### PR TITLE
refactor: unify ranking grid layout

### DIFF
--- a/src/components/shared/RankingGridCard.jsx
+++ b/src/components/shared/RankingGridCard.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import RankingMovementIndicator from '@/components/shared/RankingMovementIndicator';
+
+const RankingGridCard = ({
+  player,
+  rank,
+  headshotSrc,
+  logoPath,
+  logoBackgroundStyle,
+  rankBackgroundClass,
+  showMovement = false,
+  movement,
+}) => {
+  const displayName = player?.display_name || player?.name || '—';
+  const teamAbbreviation = player?.team?.toUpperCase() || '—';
+
+  return (
+    <div className="inline-block">
+      <div className="bg-gradient-to-b from-[#2a2a2a] to-[#1f1f1f] rounded-lg overflow-hidden border border-white/25 transition-all hover:border-white/40 shadow-2xl">
+        <div
+          className="aspect-square w-full overflow-hidden bg-[#0a0a0a] relative border-b border-white/15"
+          style={logoBackgroundStyle}
+        >
+          <img
+            src={headshotSrc}
+            alt={displayName}
+            className="w-full h-full object-cover transition-transform group-hover:scale-105"
+            loading="eager"
+            decoding="async"
+            crossOrigin="anonymous"
+            onError={(e) => {
+              e.target.src = '/assets/headshots/default.png';
+            }}
+          />
+          <div className={`absolute top-2 left-2 ${rankBackgroundClass}`}>{rank}</div>
+        </div>
+
+        <div className="p-3 relative bg-gradient-to-b from-[#1f1f1f] to-[#1a1a1a] border-t border-white/20">
+          <div className="text-white font-medium truncate mb-1">{displayName}</div>
+          <div className="flex items-center gap-1.5">
+            {logoPath && (
+              <div className="w-4 h-4">
+                <img
+                  src={logoPath}
+                  alt={teamAbbreviation}
+                  className="w-full h-full object-contain"
+                  loading="eager"
+                  decoding="async"
+                  crossOrigin="anonymous"
+                  onError={(event) => {
+                    event.target.style.display = 'none';
+                  }}
+                />
+              </div>
+            )}
+            <span className="text-white/60 text-sm">{teamAbbreviation}</span>
+          </div>
+
+          {showMovement && movement?.moved && (
+            <div className="absolute bottom-3 right-3">
+              <RankingMovementIndicator movement={movement} showMovement />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default RankingGridCard;

--- a/src/features/ranker/RankingResults.jsx
+++ b/src/features/ranker/RankingResults.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import { LayoutGrid, ListOrdered, Download, Edit3 } from 'lucide-react';
 import useImageDownload from '@/hooks/useImageDownload';
 import AdjustableRankings from './AdjustableRankings';
+import RankingGridCard from '@/components/shared/RankingGridCard';
 
 // Mapping team abbreviations to logo file names
 const teamLogoMap = {
@@ -222,79 +223,23 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
 
     return (
       <div className="min-h-screen w-full bg-neutral-950 text-white flex items-center justify-center">
-        <div className="w-[1400px] px-24 pt-20 pb-12 flex flex-col">
+        <div className="w-[1400px] px-16 pt-20 pb-12 flex flex-col">
           {/* Header (top-left) */}
           {renderPosterHeader()}
 
           {/* Grid with 6 columns x 7 rows - matching QB Rankings format */}
           <div className="mt-6 mb-12 grid grid-cols-6 gap-x-4 gap-y-6 justify-items-center">
-            {currentRanking.slice(0, 42).map((p, idx) => {
-              const logoPath = getLogoPath(p.team);
-              const headshot = getHeadshotSrc(p);
-              const logoBackgroundStyle = getLogoBackgroundStyle(
-                p.team,
-                showLogoBg
-              );
-              const rankBackgroundStyle = getRankBackgroundStyle(p.team);
-
-              return (
-                <div key={p.id} className="w-[180px]">
-                  {/* Card with fixed width */}
-                  <div className="bg-gradient-to-b from-[#2a2a2a] to-[#1f1f1f] rounded-lg overflow-hidden border border-white/25 transition-all hover:border-white/40 shadow-2xl">
-                    {/* Headshot Container with overlaid rank - fixed aspect ratio */}
-                    <div
-                      className="w-[180px] h-[180px] overflow-hidden bg-[#0a0a0a] relative border-b border-white/15"
-                      style={logoBackgroundStyle}
-                    >
-                      <img
-                        src={headshot}
-                        alt={p.name}
-                        className="w-full h-full object-cover transition-transform group-hover:scale-105"
-                        loading="eager"
-                        decoding="async"
-                        crossOrigin="anonymous"
-                        onError={(e) => {
-                          e.target.src = '/assets/headshots/default.png';
-                        }}
-                      />
-                      {/* Rank overlay in corner */}
-                      <div
-                        className={`absolute top-2 left-2 ${rankBackgroundStyle}`}
-                      >
-                        {idx + 1}
-                      </div>
-                    </div>
-
-                    {/* Info Section - increased height to prevent text clipping */}
-                    <div className="p-3 h-[70px] relative bg-gradient-to-b from-[#1f1f1f] to-[#1a1a1a] border-t border-white/20 flex flex-col">
-                      <div className="text-white font-medium truncate text-sm mb-1 leading-normal overflow-visible">
-                        {p.display_name || p.name}
-                      </div>
-                      <div className="flex items-center gap-1.5 mt-auto">
-                        {logoPath && (
-                          <div className="w-4 h-4 flex-shrink-0">
-                            <img
-                              src={logoPath}
-                              alt={p.team}
-                              className="w-full h-full object-contain"
-                              loading="eager"
-                              decoding="async"
-                              crossOrigin="anonymous"
-                              onError={(e) => {
-                                e.target.style.display = 'none';
-                              }}
-                            />
-                          </div>
-                        )}
-                        <span className="text-white/60 text-xs truncate">
-                          {p.team?.toUpperCase() || '—'}
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
+            {currentRanking.slice(0, 42).map((p, idx) => (
+              <RankingGridCard
+                key={p.id || p.player_id || idx}
+                player={p}
+                rank={idx + 1}
+                headshotSrc={getHeadshotSrc(p)}
+                logoPath={getLogoPath(p.team)}
+                logoBackgroundStyle={getLogoBackgroundStyle(p.team, showLogoBg)}
+                rankBackgroundClass={getRankBackgroundStyle(p.team)}
+              />
+            ))}
           </div>
 
           {/* Footer */}
@@ -474,73 +419,20 @@ const RankingResults = ({ ranking = [], onRankingAdjusted }) => {
 
             {/* Grid with 6 columns x 7 rows - matching QB Rankings format */}
             <div className="mt-6 mb-12 grid grid-cols-6 gap-x-4 gap-y-6 justify-items-center">
-              {currentRanking.slice(0, 42).map((p, idx) => {
-                const logoPath = getLogoPath(p.team);
-                const headshot = getHeadshotSrc(p);
-                const logoBackgroundStyle = getLogoBackgroundStyle(
-                  p.team,
-                  showLogoBg
-                );
-                const rankBackgroundStyle = getRankBackgroundStyle(p.team);
-
-                return (
-                  <div key={p.id} className="w-[180px]">
-                    {/* Card with fixed width */}
-                    <div className="bg-gradient-to-b from-[#2a2a2a] to-[#1f1f1f] rounded-lg overflow-hidden border border-white/25 transition-all hover:border-white/40 shadow-2xl">
-                      {/* Headshot Container with overlaid rank - fixed aspect ratio */}
-                      <div
-                        className="w-[180px] h-[180px] overflow-hidden bg-[#0a0a0a] relative border-b border-white/15"
-                        style={logoBackgroundStyle}
-                      >
-                        <img
-                          src={headshot}
-                          alt={p.name}
-                          className="w-full h-full object-cover transition-transform group-hover:scale-105"
-                          loading="eager"
-                          decoding="async"
-                          crossOrigin="anonymous"
-                          onError={(e) => {
-                            e.target.src = '/assets/headshots/default.png';
-                          }}
-                        />
-                        {/* Rank overlay in corner */}
-                        <div
-                          className={`absolute top-2 left-2 ${rankBackgroundStyle}`}
-                        >
-                          {idx + 1}
-                        </div>
-                      </div>
-
-                      {/* Info Section - increased height to prevent text clipping */}
-                      <div className="p-3 h-[70px] relative bg-gradient-to-b from-[#1f1f1f] to-[#1a1a1a] border-t border-white/20 flex flex-col">
-                        <div className="text-white font-medium truncate text-sm mb-1 leading-normal overflow-visible">
-                          {p.display_name || p.name}
-                        </div>
-                        <div className="flex items-center gap-1.5 mt-auto">
-                          {logoPath && (
-                            <div className="w-4 h-4 flex-shrink-0">
-                              <img
-                                src={logoPath}
-                                alt={p.team}
-                                className="w-full h-full object-contain"
-                                loading="eager"
-                                decoding="async"
-                                crossOrigin="anonymous"
-                                onError={(e) => {
-                                  e.target.style.display = 'none';
-                                }}
-                              />
-                            </div>
-                          )}
-                          <span className="text-white/60 text-xs truncate">
-                            {p.team?.toUpperCase() || '—'}
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                );
-              })}
+              {currentRanking.slice(0, 42).map((p, idx) => (
+                <RankingGridCard
+                  key={p.id || p.player_id || idx}
+                  player={p}
+                  rank={idx + 1}
+                  headshotSrc={getHeadshotSrc(p)}
+                  logoPath={getLogoPath(p.team)}
+                  logoBackgroundStyle={getLogoBackgroundStyle(
+                    p.team,
+                    showLogoBg
+                  )}
+                  rankBackgroundClass={getRankBackgroundStyle(p.team)}
+                />
+              ))}
             </div>
 
             {/* Footer */}

--- a/src/features/rankings/QBRankingsExport.jsx
+++ b/src/features/rankings/QBRankingsExport.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { LayoutGrid, ListOrdered, Download, X, TrendingUp } from 'lucide-react';
 import useImageDownload from '@/hooks/useImageDownload';
-import RankingMovementIndicator from '@/components/shared/RankingMovementIndicator';
+import RankingGridCard from '@/components/shared/RankingGridCard';
 
 // Mapping team abbreviations to logo file names (copied from RankingResults)
 const teamLogoMap = {
@@ -116,84 +116,6 @@ const getHeadshotSrc = (qb) =>
   qb?.headshotUrl ||
   qb?.imageUrl ||
   `/assets/headshots/${qb?.player_id || qb?.id}.png`;
-
-const GridCard = ({
-  qb,
-  rank,
-  showLogoBg,
-  showMovement,
-  movementData = {},
-}) => {
-  const logoPath = getLogoPath(qb.team);
-  const headshot = getHeadshotSrc(qb);
-  const logoBackgroundStyle = getLogoBackgroundStyle(qb.team, showLogoBg);
-  const rankBackgroundStyle = getRankBackgroundStyle(qb.team);
-  const movement = movementData?.[qb.id];
-
-  return (
-    <div className="inline-block">
-      {/* Card */}
-      <div className="bg-gradient-to-b from-[#2a2a2a] to-[#1f1f1f] rounded-lg overflow-hidden border border-white/25 transition-all hover:border-white/40 shadow-2xl">
-        {/* Headshot Container with overlaid rank */}
-        <div
-          className="aspect-square w-full overflow-hidden bg-[#0a0a0a] relative border-b border-white/15"
-          style={logoBackgroundStyle}
-        >
-          <img
-            src={headshot}
-            alt={qb.name}
-            className="w-full h-full object-cover transition-transform group-hover:scale-105"
-            loading="eager"
-            decoding="async"
-            crossOrigin="anonymous"
-            onError={(e) => {
-              e.target.src = '/assets/headshots/default.png';
-            }}
-          />
-          {/* Rank overlay in corner */}
-          <div className={`absolute top-2 left-2 ${rankBackgroundStyle}`}>
-            {rank}
-          </div>
-        </div>
-
-        {/* Info Section */}
-        <div className="p-3 relative bg-gradient-to-b from-[#1f1f1f] to-[#1a1a1a] border-t border-white/20">
-          <div className="text-white font-medium truncate mb-1">{qb.name}</div>
-          <div className="flex items-center gap-1.5">
-            {logoPath && (
-              <div className="w-4 h-4">
-                <img
-                  src={logoPath}
-                  alt={qb.team}
-                  className="w-full h-full object-contain"
-                  loading="eager"
-                  decoding="async"
-                  crossOrigin="anonymous"
-                  onError={(e) => {
-                    e.target.style.display = 'none';
-                  }}
-                />
-              </div>
-            )}
-            <span className="text-white/60 text-sm">
-              {qb.team?.toUpperCase() || '—'}
-            </span>
-          </div>
-
-          {/* Movement indicator positioned absolutely in bottom-right */}
-          {showMovement && movement?.moved && (
-            <div className="absolute bottom-3 right-3">
-              <RankingMovementIndicator
-                movement={movement}
-                showMovement={true}
-              />
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-};
 
 const QBRankingsExport = ({
   rankings,
@@ -410,13 +332,19 @@ const QBRankingsExport = ({
           {/* Grid with 6 columns x 7 rows - back to clean layout before dividers */}
           <div className="mt-6 mb-12 grid grid-cols-6 gap-x-4 gap-y-6 justify-items-center">
             {rankings.slice(0, 42).map((qb, idx) => (
-              <GridCard
+              <RankingGridCard
                 key={qb.id || qb.player_id || idx}
-                qb={qb}
+                player={qb}
                 rank={idx + 1}
-                showLogoBg={showLogoBg}
+                headshotSrc={getHeadshotSrc(qb)}
+                logoPath={getLogoPath(qb.team)}
+                logoBackgroundStyle={getLogoBackgroundStyle(
+                  qb.team,
+                  showLogoBg
+                )}
+                rankBackgroundClass={getRankBackgroundStyle(qb.team)}
                 showMovement={showMovement}
-                movementData={movementData}
+                movement={movementData?.[qb.id]}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
- create a shared `RankingGridCard` component so ranking views reuse the same markup
- swap the ranker results grid to use the shared card and match the manual personal ranking layout
- update personal ranking export to consume the shared card and keep the export container spacing identical

## Testing
- npm run lint *(fails: existing lint violations throughout the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ac6a24888326bafa959a2f137304